### PR TITLE
Check for presence of 'min_date' options key before referencing it.

### DIFF
--- a/includes/DateTimePicker.php
+++ b/includes/DateTimePicker.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'DateTimePicker' ) ) {
 			// setup variables
 			$min_time = $opts['minTime'];
 			$max_time = $opts['maxTime'];
-			$min_date = $opts['min_date'];
+			$min_date = isset( $opts['min_date'] ) ? $opts['min_date'] : null;
 			$step     = $opts['step'];
 			$allowed  = $opts['allowed_times'];
 			$offset   = isset( $opts['offset'] ) ? intval( $opts['offset'] ) : 0;


### PR DESCRIPTION
Line 280 of DateTimePicker.php grabs the value of `min_date` from the passed options, but doesn't test for its existence before accessing it, and that key isn't guaranteed to be present in the options.  Presently, it throws a silent error into the PHP error log about the missing key.

This PR wraps the `min_date` access in an isset() check to silence the error.